### PR TITLE
feat: add localPort, scheme properties to kubernetes-dashboard entrypoint

### DIFF
--- a/packages/kubernetes-dashboard/package.yaml
+++ b/packages/kubernetes-dashboard/package.yaml
@@ -8,3 +8,5 @@ manifests:
 entrypoints:
   - serviceName: kubernetes-dashboard
     port: 443
+    localPort: 8443
+    scheme: https


### PR DESCRIPTION
Note: These changes do not affect the latest version, but https://github.com/glasskube/glasskube/pull/245 is required for the changes to take effect.