### PR TITLE
feat(keptn): add manifest based installation that fixes usage of cert-manager.io

### DIFF
--- a/packages/keptn/v0.10.0+3/keptn-cert.yaml
+++ b/packages/keptn/v0.10.0+3/keptn-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keptn-certs
+  namespace: keptn-system
+spec:
+  dnsNames:
+    - lifecycle-webhook-service.keptn-system.svc
+    - lifecycle-webhook-service.keptn-system.svc.cluster.local
+    - metrics-webhook-service.keptn-system.svc
+    - metrics-webhook-service.keptn-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: keptn-selfsigned-issuer
+  secretName: keptn-certs

--- a/packages/keptn/v0.10.0+3/keptn-issuer.yaml
+++ b/packages/keptn/v0.10.0+3/keptn-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: keptn-selfsigned-issuer
+  namespace: keptn-system
+spec:
+  selfSigned: {}

--- a/packages/keptn/v0.10.0+3/package.yaml
+++ b/packages/keptn/v0.10.0+3/package.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://glasskube.dev/schemas/v1/package-manifest.json
+
+name: "keptn"
+shortDescription: >-
+  Supercharge your deployments with Keptn! Keptn provides a “cloud-native” approach for managing the application
+  release lifecycle metrics, observability, health checks, with pre- and post-deployment evaluations and tasks.
+iconUrl: "https://avatars.githubusercontent.com/u/46796476"
+defaultNamespace: "keptn-system"
+helm:
+  repositoryUrl: "https://charts.lifecycle.keptn.sh"
+  chartName: "keptn"
+  chartVersion: "v0.4.0"
+  values:
+    global:
+      certManagerEnabled: false
+      caInjectionAnnotations:
+        cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    metricsOperator:
+      enabled: false
+manifests:
+  - url: https://glasskube.github.io/packages/packages/keptn/v0.10.0+2/keptn-cert.yaml
+  - url: https://glasskube.github.io/packages/packages/keptn/v0.10.0+2/keptn-issuer.yaml
+dependencies:
+  - name: "cert-manager"

--- a/packages/keptn/v2.0.0-rc.1+1/keptn-cert.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/keptn-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keptn-certs
+  namespace: keptn-system
+spec:
+  dnsNames:
+    - lifecycle-webhook-service.keptn-system.svc
+    - lifecycle-webhook-service.keptn-system.svc.cluster.local
+    - metrics-webhook-service.keptn-system.svc
+    - metrics-webhook-service.keptn-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: keptn-selfsigned-issuer
+  secretName: keptn-certs

--- a/packages/keptn/v2.0.0-rc.1+1/keptn-issuer.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/keptn-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: keptn-selfsigned-issuer
+  namespace: keptn-system
+spec:
+  selfSigned: {}

--- a/packages/keptn/v2.0.0-rc.1+1/keptn.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/keptn.yaml
@@ -1,0 +1,9024 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnappcontexts.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppContext
+    listKind: KeptnAppContextList
+    plural: keptnappcontexts
+    singular: keptnappcontext
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppContext is the Schema for the keptnappcontexts API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppContextSpec defines the desired state of KeptnAppContext
+            properties:
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: KeptnAppContextStatus defines the observed state of KeptnAppContext
+            properties:
+              status:
+                description: unused field
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnappcreationrequests.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppCreationRequest
+    listKind: KeptnAppCreationRequestList
+    plural: keptnappcreationrequests
+    singular: keptnappcreationrequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnapps.lifecycle.keptn.sh
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: lifecycle-webhook-service
+          namespace: keptn-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnApp
+    listKind: KeptnAppList
+    plural: keptnapps
+    singular: keptnapp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                type: integer
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnappversions.lifecycle.keptn.sh
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: lifecycle-webhook-service
+          namespace: keptn-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppVersion
+    listKind: KeptnAppVersionList
+    plural: keptnappversions
+    shortNames:
+    - kav
+    singular: keptnappversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceID is a map storing TraceIDs of OpenTelemetry
+                  spans in lifecycle phases
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              revision:
+                default: 1
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnconfigs.options.keptn.sh
+spec:
+  group: options.keptn.sh
+  names:
+    kind: KeptnConfig
+    listKind: KeptnConfigList
+    plural: keptnconfigs
+    singular: keptnconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnConfig is the Schema for the keptnconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnConfigSpec defines the desired state of KeptnConfig
+            properties:
+              OTelCollectorUrl:
+                description: OTelCollectorUrl can be used to set the Open Telemetry
+                  collector that the lifecycle operator should use
+                type: string
+              cloudEventsEndpoint:
+                description: CloudEventsEndpoint can be used to set the endpoint where
+                  Cloud Events should be posted by the lifecycle operator
+                type: string
+              keptnAppCreationRequestTimeoutSeconds:
+                default: 30
+                description: |-
+                  KeptnAppCreationRequestTimeoutSeconds is used to set the interval in which automatic app discovery
+                  searches for workload to put into the same auto-generated KeptnApp
+                type: integer
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnevaluationdefinitions.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluationDefinition
+    listKind: KeptnEvaluationDefinitionList
+    plural: keptnevaluationdefinitions
+    shortNames:
+    - ked
+    singular: keptnevaluationdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnevaluations.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluation
+    listKind: KeptnEvaluationList
+    plural: keptnevaluations
+    shortNames:
+    - ke
+    singular: keptnevaluation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptntaskdefinitions.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTaskDefinition
+    listKind: KeptnTaskDefinitionList
+    plural: keptntaskdefinitions
+    singular: keptntaskdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptntasks.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTask
+    listKind: KeptnTaskList
+    plural: keptntasks
+    singular: keptntask
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata contains additional key-value pairs for
+                      contextual information.
+                    type: object
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnworkloads.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkload
+    listKind: KeptnWorkloadList
+    plural: keptnworkloads
+    singular: keptnworkload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    crdGroup: lifecycle.keptn.sh
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: keptnworkloadversions.lifecycle.keptn.sh
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkloadVersion
+    listKind: KeptnWorkloadVersionList
+    plural: keptnworkloadversions
+    shortNames:
+    - kwv
+    singular: keptnworkloadversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              appContextMetadata:
+                additionalProperties:
+                  type: string
+                description: AppContextMetadata contains metadata from the related
+                  KeptnAppVersion.
+                type: object
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: keptn-scheduler
+  namespace: keptn-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator
+  namespace: keptn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: leader-election-role
+  namespace: keptn-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-leader-election-role
+  namespace: keptn-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: keptn-lifecycleOperator-server-resources
+  namespace: keptn-system
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: keptn-scheduler
+  namespace: keptn-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - pods/binding
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  - storageclasses
+  - csidrivers
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.sigs.k8s.io
+  resources:
+  - podgroups
+  - elasticquotas
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-role
+  namespace: keptn-system
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcontexts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluationdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: extension-apiserver-authentication-reader
+  namespace: keptn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: keptn-scheduler
+  namespace: keptn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-leader-election-rolebinding
+  namespace: keptn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lifecycle-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: lifecycle-operator
+  namespace: keptn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-rolebinding
+  namespace: keptn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lifecycle-operator-role
+subjects:
+- kind: ServiceAccount
+  name: lifecycle-operator
+  namespace: keptn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: keptn-scheduler
+  namespace: keptn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keptn-scheduler
+subjects:
+- kind: ServiceAccount
+  name: keptn-scheduler
+  namespace: keptn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-rolebinding
+  namespace: keptn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lifecycle-operator-role
+subjects:
+- kind: ServiceAccount
+  name: lifecycle-operator
+  namespace: keptn-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: ":8081"
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: "6b866dd9.keptn.sh"
+    metrics:
+      bindAddress: "127.0.0.1:8080"
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-manager-config
+  namespace: keptn-system
+---
+apiVersion: v1
+data:
+  scheduler-config.yaml: "apiVersion: kubescheduler.config.k8s.io/v1beta3\nkind: KubeSchedulerConfiguration\nleaderElection:\n
+    \ leaderElect: false\nprofiles: \n  - plugins:\n      permit:\n        enabled:\n
+    \       - name: KLCPermit\n    schedulerName: keptn-scheduler\n"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: scheduler-config
+  namespace: keptn-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    control-plane: lifecycle-operator
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-operator-metrics-service
+  namespace: keptn-system
+spec:
+  ports:
+  - name: metrics
+    port: 2222
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/name: lifecycle-operator
+    control-plane: lifecycle-operator
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: lifecycle-webhook-service
+  namespace: keptn-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/name: lifecycle-operator
+    control-plane: lifecycle-operator
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    control-plane: lifecycle-operator
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: lifecycle-operator
+  namespace: keptn-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keptn
+      app.kubernetes.io/name: lifecycle-operator
+      control-plane: lifecycle-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: lifecycle-operator
+        metrics.dynatrace.com/port: "2222"
+        metrics.dynatrace.com/scrape: "true"
+      labels:
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/name: lifecycle-operator
+        control-plane: lifecycle-operator
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: FUNCTION_RUNNER_IMAGE
+          value: ghcr.io/keptn/deno-runtime:v2.0.1
+        - name: PYTHON_RUNNER_IMAGE
+          value: ghcr.io/keptn/python-runtime:v1.0.2
+        - name: KEPTN_APP_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_CREATION_REQUEST_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_EVALUATION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_DEFINITION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_DORA_METRICS_PORT
+          value: "2222"
+        - name: OPTIONS_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: SCHEDULING_GATES_ENABLED
+          value: "false"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        - name: CERT_MANAGER_ENABLED
+          value: "false"
+        image: ghcr.io/keptn/lifecycle-operator:v0.9.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: lifecycle-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 2222
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp/webhook/certs/
+          name: keptn-certs
+      imagePullSecrets: []
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: lifecycle-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: keptn-certs
+        secret:
+          secretName: keptn-certs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    component: scheduler
+    helm.sh/chart: lifecycle-operator-0.2.0
+  name: scheduler
+  namespace: keptn-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keptn
+      app.kubernetes.io/name: lifecycle-operator
+      component: scheduler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/name: lifecycle-operator
+        component: scheduler
+    spec:
+      containers:
+      - command:
+        - /bin/kube-scheduler
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        env:
+        - name: OTEL_COLLECTOR_URL
+          value: otel-collector:4317
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: ghcr.io/keptn/scheduler:v0.9.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+        name: scheduler
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+        resources:
+          limits:
+            cpu: 300m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: scheduler-config
+          readOnly: true
+      imagePullSecrets: []
+      serviceAccountName: keptn-scheduler
+      volumes:
+      - configMap:
+          name: scheduler-config
+        name: scheduler-config
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: lifecycle-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: lifecycle-webhook-service
+      namespace: keptn-system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.keptn.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: NotIn
+      values:
+      - lifecycle-operator
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - cert-manager
+      - keptn-system
+      - observability
+      - monitoring
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - keptn-system
+      - kube-system
+      - kube-public
+      - kube-node-lease
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+    keptn.sh/inject-cert: "true"
+  name: lifecycle-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: lifecycle-webhook-service
+      namespace: keptn-system
+      path: /validate-lifecycle-keptn-sh-v1beta1-keptntaskdefinition
+  failurePolicy: Fail
+  name: vkeptntaskdefinition.kb.io
+  rules:
+  - apiGroups:
+    - lifecycle.keptn.sh
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keptntaskdefinitions
+  sideEffects: None

--- a/packages/keptn/v2.0.0-rc.1+1/kustomization.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: "kustomize.config.k8s.io/v1beta1"
+kind: "Kustomization"
+namespace: keptn-system
+
+resources:
+  - template.yaml
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: lifecycle-operator
+      namespace: keptn-system
+    path: patch.yaml

--- a/packages/keptn/v2.0.0-rc.1+1/package.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/package.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://glasskube.dev/schemas/v1/package-manifest.json
+
+# helm template keptn/keptn --namespace keptn-system --name-template keptn --version v0.4.0 --values values.yaml > template.yaml
+# kubectl kustomize . > keptn.yaml
+
+name: "keptn"
+shortDescription: >-
+  Supercharge your deployments with Keptn! Keptn provides a “cloud-native” approach for managing the application
+  release lifecycle metrics, observability, health checks, with pre- and post-deployment evaluations and tasks.
+iconUrl: "https://avatars.githubusercontent.com/u/46796476"
+defaultNamespace: "keptn-system"
+helm:
+  repositoryUrl: "https://charts.lifecycle.keptn.sh"
+  chartName: "keptn"
+  chartVersion: "v0.5.0"
+  values:
+    global:
+      certManagerEnabled: false
+      caInjectionAnnotations:
+        cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+    metricsOperator:
+      enabled: false
+manifests:
+  - url: https://glasskube.github.io/packages/packages/keptn/v2.0.0-rc.1+1/keptn.yaml
+  - url: https://glasskube.github.io/packages/packages/keptn/v2.0.0-rc.1+1/keptn-cert.yaml
+  - url: https://glasskube.github.io/packages/packages/keptn/v2.0.0-rc.1+1/keptn-issuer.yaml
+dependencies:
+  - name: "cert-manager"

--- a/packages/keptn/v2.0.0-rc.1+1/patch.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lifecycle-operator
+  namespace: keptn-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: lifecycle-operator
+          volumeMounts:
+            - mountPath: "/tmp/webhook/certs/"
+              name: keptn-certs
+      volumes:
+        - name: keptn-certs
+          secret:
+            secretName: keptn-certs

--- a/packages/keptn/v2.0.0-rc.1+1/template.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/template.yaml
@@ -1,0 +1,9053 @@
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keptn-scheduler
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lifecycle-operator
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lifecycle-manager-config
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: ":8081"
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: "6b866dd9.keptn.sh"
+    metrics:
+      bindAddress: "127.0.0.1:8080"
+    webhook:
+      port: 9443
+---
+# Source: keptn/charts/lifecycleOperator/templates/scheduler-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles: 
+      - plugins:
+          permit:
+            enabled:
+            - name: KLCPermit
+        schedulerName: keptn-scheduler
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnapp-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnapps.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: 'lifecycle-webhook-service'
+          namespace: 'keptn-system'
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnApp
+    listKind: KeptnAppList
+    plural: keptnapps
+    singular: keptnapp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                type: integer
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappcontext-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappcontexts.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: 'keptn-system/keptn-certs'
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppContext
+    listKind: KeptnAppContextList
+    plural: keptnappcontexts
+    singular: keptnappcontext
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppContext is the Schema for the keptnappcontexts API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppContextSpec defines the desired state of KeptnAppContext
+            properties:
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: KeptnAppContextStatus defines the observed state of KeptnAppContext
+            properties:
+              status:
+                description: unused field
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappcreationrequest-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappcreationrequests.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppCreationRequest
+    listKind: KeptnAppCreationRequestList
+    plural: keptnappcreationrequests
+    singular: keptnappcreationrequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappversion-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappversions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: 'lifecycle-webhook-service'
+          namespace: 'keptn-system'
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppVersion
+    listKind: KeptnAppVersionList
+    plural: keptnappversions
+    shortNames:
+    - kav
+    singular: keptnappversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceID is a map storing TraceIDs of OpenTelemetry
+                  spans in lifecycle phases
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              revision:
+                default: 1
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnconfig-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnconfigs.options.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: options.keptn.sh
+  names:
+    kind: KeptnConfig
+    listKind: KeptnConfigList
+    plural: keptnconfigs
+    singular: keptnconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnConfig is the Schema for the keptnconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnConfigSpec defines the desired state of KeptnConfig
+            properties:
+              OTelCollectorUrl:
+                description: OTelCollectorUrl can be used to set the Open Telemetry
+                  collector that the lifecycle operator should use
+                type: string
+              cloudEventsEndpoint:
+                description: CloudEventsEndpoint can be used to set the endpoint where
+                  Cloud Events should be posted by the lifecycle operator
+                type: string
+              keptnAppCreationRequestTimeoutSeconds:
+                default: 30
+                description: |-
+                  KeptnAppCreationRequestTimeoutSeconds is used to set the interval in which automatic app discovery
+                  searches for workload to put into the same auto-generated KeptnApp
+                type: integer
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnevaluation-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnevaluations.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluation
+    listKind: KeptnEvaluationList
+    plural: keptnevaluations
+    shortNames:
+    - ke
+    singular: keptnevaluation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnevaluationdefinition-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnevaluationdefinitions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluationDefinition
+    listKind: KeptnEvaluationDefinitionList
+    plural: keptnevaluationdefinitions
+    shortNames:
+    - ked
+    singular: keptnevaluationdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptntask-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptntasks.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTask
+    listKind: KeptnTaskList
+    plural: keptntasks
+    singular: keptntask
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata contains additional key-value pairs for
+                      contextual information.
+                    type: object
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptntaskdefinition-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptntaskdefinitions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTaskDefinition
+    listKind: KeptnTaskDefinitionList
+    plural: keptntaskdefinitions
+    singular: keptntaskdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnworkload-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnworkloads.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkload
+    listKind: KeptnWorkloadList
+    plural: keptnworkloads
+    singular: keptnworkload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnworkloadversion-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnworkloadversions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkloadVersion
+    listKind: KeptnWorkloadVersionList
+    plural: keptnworkloadversions
+    shortNames:
+    - kwv
+    singular: keptnworkloadversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              appContextMetadata:
+                additionalProperties:
+                  type: string
+                description: AppContextMetadata contains metadata from the related
+                  KeptnAppVersion.
+                type: object
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptn-scheduler-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keptn-scheduler
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - pods/binding
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  - storageclasses
+  - csidrivers
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.sigs.k8s.io
+  resources:
+  - podgroups
+  - elasticquotas
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lifecycle-operator-role
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcontexts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluationdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs/status
+  verbs:
+  - get
+---
+# Source: keptn/charts/lifecycleOperator/templates/server-resources-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keptn-lifecycleOperator-server-resources
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptn-scheduler-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keptn-scheduler
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'keptn-scheduler'
+subjects:
+- kind: ServiceAccount
+  name: 'keptn-scheduler'
+  namespace: 'keptn-system'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lifecycle-operator-rolebinding
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'lifecycle-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'keptn-system'
+---
+# Source: keptn/charts/lifecycleOperator/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lifecycle-operator-leader-election-role
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: keptn/charts/lifecycleOperator/templates/extension-apiserver-authentication-reader-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extension-apiserver-authentication-reader
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'extension-apiserver-authentication-reader'
+subjects:
+- kind: ServiceAccount
+  name: 'keptn-scheduler'
+  namespace: 'keptn-system'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lifecycle-operator-leader-election-rolebinding
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'lifecycle-operator-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'keptn-system'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lifecycle-operator-rolebinding
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'lifecycle-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'keptn-system'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lifecycle-operator-metrics-service
+  namespace: "keptn-system"
+  labels:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/instance: keptn
+  ports:
+  - name: metrics
+    port: 2222
+    protocol: TCP
+    targetPort: metrics
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lifecycle-webhook-service
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/instance: keptn
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lifecycle-operator
+  namespace: "keptn-system"
+  labels:
+    app.kubernetes.io/part-of: keptn
+    control-plane: lifecycle-operator
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: lifecycle-operator
+      app.kubernetes.io/name: lifecycle-operator
+      app.kubernetes.io/instance: keptn
+  template:
+    metadata:
+      labels:
+        control-plane: lifecycle-operator
+        app.kubernetes.io/name: lifecycle-operator
+        app.kubernetes.io/instance: keptn
+      annotations:
+        kubectl.kubernetes.io/default-container: lifecycle-operator
+        metrics.dynatrace.com/port: "2222"
+        metrics.dynatrace.com/scrape: "true"
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: FUNCTION_RUNNER_IMAGE
+          value: "ghcr.io/keptn/deno-runtime:v2.0.1"
+        - name: PYTHON_RUNNER_IMAGE
+          value: "ghcr.io/keptn/python-runtime:v1.0.2"
+        - name: KEPTN_APP_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_CREATION_REQUEST_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_EVALUATION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_DEFINITION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_DORA_METRICS_PORT
+          value: "2222"
+        - name: OPTIONS_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: SCHEDULING_GATES_ENABLED
+          value: "false"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        - name: CERT_MANAGER_ENABLED
+          value: "false"
+        image: ghcr.io/keptn/lifecycle-operator:v0.9.0
+        imagePullPolicy: Always
+        name: lifecycle-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 2222
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      imagePullSecrets: []
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: lifecycle-operator
+      terminationGracePeriodSeconds: 10
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduler
+  namespace: "keptn-system"
+  labels:
+    component: scheduler
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: scheduler
+      app.kubernetes.io/name: lifecycle-operator
+      app.kubernetes.io/instance: keptn
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        app.kubernetes.io/name: lifecycle-operator
+        app.kubernetes.io/instance: keptn
+    spec:
+      containers:
+      - command:
+        - /bin/kube-scheduler
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        env:
+        - name: OTEL_COLLECTOR_URL
+          value: "otel-collector:4317"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: ghcr.io/keptn/scheduler:v0.9.0
+        imagePullPolicy: Always
+        name: scheduler
+        resources:
+          limits:
+            cpu: 300m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: scheduler-config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+      imagePullSecrets: []
+      serviceAccountName: keptn-scheduler
+      volumes:
+      - configMap:
+          name: scheduler-config
+        name: scheduler-config
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-mutating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: lifecycle-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/part-of: "keptn"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'lifecycle-webhook-service'
+      namespace: 'keptn-system'
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.keptn.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: NotIn
+      values:
+      - lifecycle-operator
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:  ["cert-manager","keptn-system","observability","monitoring"]
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - 'keptn-system'
+      - kube-system
+      - kube-public
+      - kube-node-lease
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-validating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: lifecycle-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+  labels:
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.0
+    helm.sh/chart: lifecycle-operator-0.2.0
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'lifecycle-webhook-service'
+      namespace: 'keptn-system'
+      path: /validate-lifecycle-keptn-sh-v1beta1-keptntaskdefinition
+  failurePolicy: Fail
+  name: vkeptntaskdefinition.kb.io
+  rules:
+  - apiGroups:
+    - lifecycle.keptn.sh
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keptntaskdefinitions
+  sideEffects: None

--- a/packages/keptn/v2.0.0-rc.1+1/values.yaml
+++ b/packages/keptn/v2.0.0-rc.1+1/values.yaml
@@ -1,0 +1,7 @@
+# helm template keptn/keptn --namespace keptn-system --name-template keptn --version v0.4.0 --values values.yaml > template.yaml
+global:
+  certManagerEnabled: false
+  caInjectionAnnotations:
+    cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+metricsOperator:
+  enabled: false

--- a/packages/keptn/versions.yaml
+++ b/packages/keptn/versions.yaml
@@ -2,3 +2,5 @@ latestVersion: "v0.10.0+1"
 versions:
 - version: "v0.10.0+1"
 - version: "v0.10.0+2"
+- version: "v0.10.0+3"
+- version: "v2.0.0-rc.1+1"


### PR DESCRIPTION
Follow-up to: https://github.com/glasskube/packages/pull/32

Related to: https://github.com/keptn/lifecycle-toolkit/issues/3242