### PR TITLE
feat(keptn): update to latest release candidate helm chart with cert-manager dependency

### DIFF
--- a/packages/keptn/v2.0.0-rc.2+1/keptn-cert.yaml
+++ b/packages/keptn/v2.0.0-rc.2+1/keptn-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keptn-certs
+  namespace: keptn-system
+spec:
+  dnsNames:
+    - lifecycle-webhook-service.keptn-system.svc
+    - lifecycle-webhook-service.keptn-system.svc.cluster.local
+    - metrics-webhook-service.keptn-system.svc
+    - metrics-webhook-service.keptn-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: keptn-selfsigned-issuer
+  secretName: keptn-certs

--- a/packages/keptn/v2.0.0-rc.2+1/keptn-issuer.yaml
+++ b/packages/keptn/v2.0.0-rc.2+1/keptn-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: keptn-selfsigned-issuer
+  namespace: keptn-system
+spec:
+  selfSigned: {}

--- a/packages/keptn/v2.0.0-rc.2+1/package.yaml
+++ b/packages/keptn/v2.0.0-rc.2+1/package.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://glasskube.dev/schemas/v1/package-manifest.json
+
+name: "keptn"
+shortDescription: Toolkit for cloud-native application lifecycle management
+longDescription: >-
+  Supercharge your deployments with Keptn! Keptn provides a “cloud-native” approach for managing the application
+  release lifecycle metrics, observability, health checks, with pre- and post-deployment evaluations and tasks.
+iconUrl: "https://raw.githubusercontent.com/cncf/artwork/main/projects/keptn/icon/color/keptn-icon-color.svg"
+defaultNamespace: "keptn-system"
+helm:
+  repositoryUrl: "https://charts.lifecycle.keptn.sh"
+  chartName: "keptn"
+  chartVersion: "v0.5.2"
+  values:
+    global:
+      certManagerEnabled: false
+      caInjectionAnnotations:
+        cert-manager.io/inject-ca-from: keptn-system/keptn-certs
+manifests:
+  - url: https://glasskube.github.io/packages/packages/keptn/v2.0.0-rc.2+1/keptn-cert.yaml
+  - url: https://glasskube.github.io/packages/packages/keptn/v2.0.0-rc.2+1/keptn-issuer.yaml
+dependencies:
+  - name: "cert-manager"

--- a/packages/keptn/versions.yaml
+++ b/packages/keptn/versions.yaml
@@ -1,6 +1,7 @@
-latestVersion: "v0.10.0+1"
+latestVersion: "v2.0.0-rc.2+1"
 versions:
 - version: "v0.10.0+1"
 - version: "v0.10.0+2"
 - version: "v0.10.0+3"
 - version: "v2.0.0-rc.1+1"
+- version: "v2.0.0-rc.2+1"


### PR DESCRIPTION
Using the latest version of keptn works due to the resolution of:

 - https://github.com/keptn/lifecycle-toolkit/issues/3242
 - https://github.com/keptn/lifecycle-toolkit/issues/3226


```
NAME                                      READY   STATUS    RESTARTS   AGE
pod/lifecycle-operator-6789df8d7f-mktph   1/1     Running   0          2m33s
pod/metrics-operator-7c7db7fd48-bwww6     1/1     Running   0          2m33s
pod/scheduler-5d8b87cd5-74b98             1/1     Running   0          2m33s

```
