### PR TITLE
feat(quickwit): use two separate fields for defaultIndexRootUri and metastoreUri

### DIFF
--- a/packages/quickwit/v0.8.1+3/package.yaml
+++ b/packages/quickwit/v0.8.1+3/package.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=https://glasskube.dev/schemas/v1/package-manifest.json
+name: quickwit
+shortDescription: Cloud-native search engine for observability
+longDescription: |
+  Quickwit is the first engine to execute complex search and analytics queries directly on cloud storage with
+  sub-second latency. Powered by Rust and its decoupled compute and storage architecture, it is designed to be
+  resource-efficient, easy to operate, and scale to petabytes of data.
+
+  Quickwit is a great fit for log management, distributed tracing, and generally immutable data such as conversational
+  data (emails, texts, messaging platforms) and event-based analytics.
+
+  Make sure that the object storage user has all permissions (e.g. `"s3:*"`) for the configured bucket.
+  For more information make sure to check out the Quickwit documentation.
+defaultNamespace: quickwit
+iconUrl: https://avatars.githubusercontent.com/u/98504233
+helm:
+  repositoryUrl: "https://helm.quickwit.io"
+  chartName: quickwit
+  chartVersion: "0.5.16"
+  values:
+    environment: {}
+    config:
+      storage:
+        s3: {}
+valueDefinitions:
+  defaultIndexRootUri:
+    type: text
+    metadata:
+      description: >
+        The default index URI is a S3 bucket which usually looks like this: "s3://<bucket-name>/<optional-base-path>"
+    constraints:
+      required: true
+      minLength: 1
+    targets:
+      - chartName: quickwit
+        patch:
+          op: add
+          path: /config/default_index_root_uri
+  s3Flavor:
+    type: options
+    metadata:
+      description: Leave empty if using genuine AWS S3
+    options:
+      - ""
+      - do
+      - garage
+      - gcp
+      - minio
+    targets:
+      - chartName: quickwit
+        valueTemplate: |
+          {{if .}}"{{.}}"{{else}}null{{end}}
+        patch:
+          op: add
+          path: /config/storage/s3/flavor
+  s3Endpoint:
+    type: text
+    metadata:
+      description: The S3 endpoint is required for alternative S3 API providers
+    targets:
+      - chartName: quickwit
+        valueTemplate: |
+          {{if .}}"{{.}}"{{else}}null{{end}}
+        patch:
+          op: add
+          path: /config/storage/s3/endpoint
+  s3Region:
+    type: text
+    targets:
+      - chartName: quickwit
+        patch:
+          op: add
+          path: /config/storage/s3/region
+  s3AccessKeyId:
+    type: text
+    targets:
+      - chartName: quickwit
+        patch:
+          op: add
+          path: /config/storage/s3/access_key_id
+  s3SecretAccessKey:
+    type: text
+    targets:
+      - chartName: quickwit
+        patch:
+          op: add
+          path: /config/storage/s3/secret_access_key
+  metastoreUri:
+    type: text
+    metadata:
+      description: >
+        If you're not using PostgreSQL and object storage, you can pick the same bucket and value you used for the defaultIndexRootUri parameter
+    constraints:
+      required: true
+      minLength: 1
+    targets:
+      - chartName: quickwit
+        patch:
+          op: add
+          path: /environment/QW_METASTORE_URI
+entrypoints:
+  - serviceName: quickwit-searcher
+    port: 7280
+references:
+  - label: ArtifactHub
+    url: https://artifacthub.io/packages/helm/quickwit/quickwit
+  - label: Website
+    url: https://quickwit.io/
+  - label: Documentation
+    url: https://quickwit.io/docs
+  - label: GitHub
+    url: https://github.com/quickwit-oss/quickwit

--- a/packages/quickwit/versions.yaml
+++ b/packages/quickwit/versions.yaml
@@ -2,3 +2,4 @@ latestVersion: v0.8.1+2
 versions:
   - version: v0.8.1+1
   - version: v0.8.1+2
+  - version: v0.8.1+3


### PR DESCRIPTION
Fix this issue: https://github.com/glasskube/glasskube/issues/818