### PR TITLE
fix(quickwit): optional and browser-conform regex

### DIFF
--- a/packages/quickwit/v0.8.1+4/package.yaml
+++ b/packages/quickwit/v0.8.1+4/package.yaml
@@ -119,7 +119,7 @@ valueDefinitions:
         DNS name for the Quickwit Ingress.
         Leave this empty to disable the Ingress.
     constraints:
-      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+      pattern: ^([a-z0-9]([\-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([\-a-z0-9]*[a-z0-9])?)*)?$
     targets:
       - patch:
           op: add


### PR DESCRIPTION
This makes the whole pattern optional, such that when an empty value (`""`) is given, the pattern is still correct. This is a workaround for the UI not allowing to "unset" a value yet. Follow-Up issue: https://github.com/glasskube/glasskube/issues/990

Also, `-` are escaped now to work in the browser. 