### PR TITLE
ci: background installation

### DIFF
--- a/.github/workflows/test-packages.yaml
+++ b/.github/workflows/test-packages.yaml
@@ -60,7 +60,14 @@ jobs:
         id: config
         run: echo "config=$(curl -fL http://host.minikube.internal:9090/packages/${{ matrix.change[0] }}/${{ matrix.change[1] }}/.test/config-values.txt)" >> $GITHUB_OUTPUT
       - name: Install package in Minikube cluster
-        run: ./glasskube install "${{ matrix.change[0] }}" --repository="local" --version="${{ matrix.change[1] }}" ${{ steps.config.outputs.config }} --yes --non-interactive
+        run: ./glasskube install "${{ matrix.change[0] }}" --repository="local" --version="${{ matrix.change[1] }}" ${{ steps.config.outputs.config }} --yes --non-interactive --no-wait
       - name: Check package status
+        timeout-minutes: 5
         run: |
-          ./glasskube describe "${{ matrix.change[0] }}" | grep -E "Status: *Ready"
+          while true; do
+            sleep 5
+            status=`./glasskube describe "${{ matrix.change[0] }}" -o json | jq -r .status`
+            if [ $status == "Ready" ]; then
+              break;
+            fi
+          done


### PR DESCRIPTION
Sometimes the `glasskube install` command returns with an `Installation Failed` status right away ("object has been modified" kind of error), returning a non-zero exit code and making the pipeline fail. This seems to be very common at least for the `kube-prometheus-stack`. Right afterwards the status changes to `Pending`, however that's too late. 

For now, I changed the pipeline such that the `install` command doesn't wait at all (`--no-wait`), and then do a status polling loop in the next step, until the status is `Ready` or it times out. 

However we could also have another look into recoverable errors. This issue might be related: https://github.com/glasskube/glasskube/issues/60

Ref #228 

The exact error message was "❌ kube-prometheus-stack installation has status Failed, reason: InstallationFailed
Message: could not ensure helm release: Operation cannot be fulfilled on helmreleases.helm.toolkit.fluxcd.io "kube-prometheus-stack-kube-prometheus-stack": the object has been modified; please apply your changes to the latest version and try again", see https://github.com/glasskube/packages/actions/runs/9967515061/job/27545889578