### PR TITLE
ci: add workflow to enable automerge on package update PRs

### DIFF
--- a/.github/workflows/automerge-package-updates.yaml
+++ b/.github/workflows/automerge-package-updates.yaml
@@ -1,0 +1,15 @@
+name: Auto-merge package updates
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: "github.actor == 'glasskube-bot' && startsWith(github.event.pull_request.title, 'chore: update package ')"
+    steps:
+      - name: Enable Pull Request Automerge
+        run: gh pr merge --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Important: depends on #306

Enable required checks in branch protection settings before merging!