### PR TITLE
feat(ingress-nginx): Change scope to namespace and allow configuration of ingress class name

### DIFF
--- a/packages/index.yaml
+++ b/packages/index.yaml
@@ -46,6 +46,7 @@ packages:
   - iconUrl: https://avatars.githubusercontent.com/u/13629408
     latestVersion: v1.9.5+1
     name: ingress-nginx
+    scope: Namespaced
     shortDescription: ingress-nginx is an Ingress controller for Kubernetes using
       NGINX as a reverse proxy and load balancer.
   - iconUrl: https://avatars.githubusercontent.com/u/128535266?s=150

--- a/packages/ingress-nginx/v1.9.5+1/.test/config-values.txt
+++ b/packages/ingress-nginx/v1.9.5+1/.test/config-values.txt
@@ -1,0 +1,1 @@
+"ingress-nginx-ns" --value "ingressClass=nginx" --value "ingressClassController=ingress-nginx"

--- a/packages/ingress-nginx/v1.9.5+1/package.yaml
+++ b/packages/ingress-nginx/v1.9.5+1/package.yaml
@@ -2,9 +2,49 @@
 
 name: "ingress-nginx"
 shortDescription: "ingress-nginx is an Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer."
+longDescription: |
+  > _**PLEASE READ:** If you previously installed this package as a `ClusterPackage`, please remove and install it as a
+  > namespace-scoped `Package` instead._
 iconUrl: "https://avatars.githubusercontent.com/u/13629408"
+scope: Namespaced
 defaultNamespace: "ingress-nginx"
 helm:
   repositoryUrl: "https://kubernetes.github.io/ingress-nginx"
   chartName: "ingress-nginx"
   chartVersion: "4.9.0"
+  values:
+    controller:
+      ingressClassResource: {}
+valueDefinitions:
+  ingressClass:
+    type: text
+    defaultValue: nginx
+    metadata:
+      description: >
+        Name of the ingressClass managed by the controller
+    constraints:
+      required: false
+    targets:
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClass
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClassResource/name
+  ingressClassController:
+    type: text
+    defaultValue: "ingress-nginx"
+    metadata:
+      description: >
+        Controller-value of the controller that is processing this ingressClass
+    constraints:
+      required: false
+    targets:
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClassResource/controllerValue
+        valueTemplate: |
+          "k8s.io\/{{ . }}"

--- a/packages/ingress-nginx/v1.9.6+1/.test/config-values.txt
+++ b/packages/ingress-nginx/v1.9.6+1/.test/config-values.txt
@@ -1,0 +1,1 @@
+"ingress-nginx-ns" --value "ingressClass=nginx" --value "ingressClassController=ingress-nginx"

--- a/packages/ingress-nginx/v1.9.6+1/package.yaml
+++ b/packages/ingress-nginx/v1.9.6+1/package.yaml
@@ -2,12 +2,52 @@
 
 name: "ingress-nginx"
 shortDescription: "ingress-nginx is an Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer."
+longDescription: |
+  > _**PLEASE READ:** If you previously installed this package as a `ClusterPackage`, please remove and install it as a
+  > namespace-scoped `Package` instead._
 iconUrl: "https://avatars.githubusercontent.com/u/13629408"
+scope: Namespaced
 defaultNamespace: "ingress-nginx"
 helm:
   repositoryUrl: "https://kubernetes.github.io/ingress-nginx"
   chartName: "ingress-nginx"
   chartVersion: "4.9.1"
+  values:
+    controller:
+      ingressClassResource: {}
 references:
   - label: "ArtifactHub"
     url: "https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx"
+valueDefinitions:
+  ingressClass:
+    type: text
+    defaultValue: nginx
+    metadata:
+      description: >
+        Name of the ingressClass managed by the controller
+    constraints:
+      required: false
+    targets:
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClass
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClassResource/name
+  ingressClassController:
+    type: text
+    defaultValue: "ingress-nginx"
+    metadata:
+      description: >
+        Controller-value of the controller that is processing this ingressClass
+    constraints:
+      required: false
+    targets:
+      - chartName: "ingress-nginx"
+        patch:
+          op: add
+          path: /controller/ingressClassResource/controllerValue
+        valueTemplate: |
+          "k8s.io\/{{ . }}"

--- a/packages/ingress-nginx/versions.yaml
+++ b/packages/ingress-nginx/versions.yaml
@@ -1,3 +1,4 @@
 latestVersion: "v1.9.5+1"
 versions:
 - version: "v1.9.5+1"
+- version: "v1.9.6+1"


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗 Please make sure you followed the conventional commit -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#1070](https://github.com/glasskube/glasskube/issues/1070)

## 📑 Description
* Change all nginx-ingress packages to namespace scoped
* Allow configuration of `ingressClass`, `ingressClassResource.name` and `ingressClassResource.controllerValue` to enable each controller to manage and process its own ingressClass
  * Default values are taken from the ingress-nginx helm chart

## ℹ Additional Information
* `versions.yaml` has been updated to `v1.9.6+1`