### PR TITLE
fix(ci): minikube tunnel

### DIFF
--- a/.github/workflows/test-packages.yaml
+++ b/.github/workflows/test-packages.yaml
@@ -50,6 +50,8 @@ jobs:
         run: curl -v "http://host.minikube.internal:9090/packages/${{ matrix.change[0] }}/${{ matrix.change[1] }}/package.yaml"
       - name: Start minikube cluster
         uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
+      - name: Minikube Tunnel
+        run: minikube tunnel &
       - name: Bootstrap Glasskube in Minikube cluster
         run: ./glasskube bootstrap --disable-telemetry --no-progress --create-default-repository=false
       - name: Add local repository


### PR DESCRIPTION
This makes the `ingress-nginx` installation work in minikube, see: https://github.com/glasskube/packages/pull/523