### PR TITLE
chore(headlamp): change repoUrl to https://kubernetes-sigs.github.io/headlamp/ for all versions

### DIFF
--- a/packages/headlamp/v0.24.0+1/package.yaml
+++ b/packages/headlamp/v0.24.0+1/package.yaml
@@ -13,7 +13,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.22.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.24.1+1/package.yaml
+++ b/packages/headlamp/v0.24.1+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.23.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.25.0+1/package.yaml
+++ b/packages/headlamp/v0.25.0+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.24.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.25.1+1/package.yaml
+++ b/packages/headlamp/v0.25.1+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.25.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.26.0+1/package.yaml
+++ b/packages/headlamp/v0.26.0+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.26.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.27.0+1/package.yaml
+++ b/packages/headlamp/v0.27.0+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.27.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin

--- a/packages/headlamp/v0.28.0+1/package.yaml
+++ b/packages/headlamp/v0.28.0+1/package.yaml
@@ -9,7 +9,7 @@ defaultNamespace: headlamp-system
 helm:
   chartName: headlamp
   chartVersion: 0.28.0
-  repositoryUrl: https://headlamp-k8s.github.io/headlamp/
+  repositoryUrl: https://kubernetes-sigs.github.io/headlamp/
   values:
     serviceAccount:
       name: headlamp-admin


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/headlamp/issues/3062