### PR TITLE
feat(attune): add Kubernetes pod resource right-sizing operator

### DIFF
--- a/packages/attune/v0.1.5+1/package.yaml
+++ b/packages/attune/v0.1.5+1/package.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://glasskube.dev/schemas/v1/package-manifest.json
+
+name: attune
+shortDescription: Safe, in-place Kubernetes pod resource right-sizing operator
+longDescription: |
+  Attune is a Kubernetes operator that uses Prometheus metrics to continuously
+  analyze CPU and memory usage and automatically adjusts container resources
+  without restarting pods, using the Kubernetes 1.32+ In-Place Pod Resize feature.
+
+  Key features:
+  - In-place pod resizing (no restarts, no evictions)
+  - Composable estimator chain (percentile, margin, confidence, bounds, change filter)
+  - HPA conflict detection
+  - Post-resize safety observation and automatic rollback
+  - Works with Prometheus, Datadog, and CloudWatch metrics
+  - kubectl plugin for dry-run and explain
+
+  > **Note:** Requires Kubernetes 1.32+ with InPlacePodVerticalScaling feature gate enabled
+  > (beta and enabled by default in K8s 1.33+).
+
+  After installation, create an AttunePolicy CR to define right-sizing behavior
+  for your workloads. See the [documentation](https://attune-io.github.io/attune/)
+  for configuration details.
+iconUrl: https://raw.githubusercontent.com/attune-io/attune/main/docs/logo.png
+defaultNamespace: attune-system
+manifests:
+  - url: https://github.com/attune-io/attune/releases/download/v0.1.5/install.yaml
+references:
+  - label: GitHub
+    url: https://github.com/attune-io/attune
+  - label: Documentation
+    url: https://attune-io.github.io/attune/
+  - label: ArtifactHub
+    url: https://artifacthub.io/packages/helm/attune/attune

--- a/packages/attune/versions.yaml
+++ b/packages/attune/versions.yaml
@@ -1,0 +1,3 @@
+latestVersion: v0.1.5+1
+versions:
+  - version: v0.1.5+1

--- a/packages/index.yaml
+++ b/packages/index.yaml
@@ -8,6 +8,10 @@ packages:
     latestVersion: v2.14.1+1
     name: argo-cd
     shortDescription: Declarative Continuous Deployment for Kubernetes
+  - iconUrl: https://raw.githubusercontent.com/attune-io/attune/main/docs/logo.png
+    latestVersion: v0.1.5+1
+    name: attune
+    shortDescription: Safe, in-place Kubernetes pod resource right-sizing operator
   - iconUrl: https://avatars.githubusercontent.com/u/12955528
     latestVersion: v1.1.0+1
     name: caddy-ingress-controller


### PR DESCRIPTION
## Summary

Add [Attune](https://github.com/attune-io/attune) to the Glasskube package catalog.

## What is Attune?

Attune is a Kubernetes operator for safe, in-place pod resource right-sizing. It uses Prometheus metrics to continuously analyze CPU and memory usage and automatically adjusts container resources without restarting pods, using the Kubernetes 1.32+ In-Place Pod Resize feature.

Key features:
- In-place pod resizing (no restarts, no evictions)
- Composable estimator chain (percentile, margin, confidence, bounds, change filter)
- HPA conflict detection
- Post-resize safety observation and automatic rollback
- Works with Prometheus, Datadog, and CloudWatch metrics
- kubectl plugin for dry-run and explain

## Package details

- **Installation method:** Kubernetes manifests (release assets)
- **Manifest URL:** `https://github.com/attune-io/attune/releases/download/v0.1.5/install.yaml`
- **Default namespace:** `attune-system`
- **License:** Apache-2.0

Related issue: https://github.com/glasskube/glasskube/issues/1564